### PR TITLE
feat(highlights): add swipeable navigation in modal

### DIFF
--- a/rada_starter/frontend/package-lock.json
+++ b/rada_starter/frontend/package-lock.json
@@ -12,7 +12,8 @@
         "axios": "^1.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-responsive": "^10.0.1"
+        "react-responsive": "^10.0.1",
+        "react-swipeable": "^7.0.2"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.0.0",
@@ -4577,6 +4578,14 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/rada_starter/frontend/package.json
+++ b/rada_starter/frontend/package.json
@@ -13,7 +13,8 @@
     "axios": "^1.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-responsive": "^10.0.1"
+    "react-responsive": "^10.0.1",
+    "react-swipeable": "^7.0.2"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/rada_starter/frontend/src/views/Highlights.jsx
+++ b/rada_starter/frontend/src/views/Highlights.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { Card, Avatar, Tooltip, Empty, Modal, Button } from 'antd'
 import { useMediaQuery } from 'react-responsive'
+import { useSwipeable } from 'react-swipeable'
 
 export default function Highlights() {
   const [highlights, setHighlights] = useState([])
@@ -35,6 +36,12 @@ export default function Highlights() {
   const goNext = () => setCurrentIndex(i => (i < highlights.length - 1 ? i + 1 : i))
 
   const selectedHighlight = currentIndex !== null ? highlights[currentIndex] : null
+
+  const swipeHandlers = useSwipeable({
+    onSwipedLeft: () => goNext(),
+    onSwipedRight: () => goPrev(),
+    trackMouse: true, // allows drag with mouse on desktop
+  })
 
   const highlightBar = (
     <div style={{ display: 'flex', gap: '12px', overflowX: 'auto', padding: '8px 0' }}>
@@ -90,7 +97,7 @@ export default function Highlights() {
         title={selectedHighlight?.title}
       >
         {selectedHighlight && (
-          <div style={{ textAlign: 'center' }}>
+          <div {...swipeHandlers} style={{ textAlign: 'center' }}>
             <img
               src={selectedHighlight.cover}
               alt={selectedHighlight.title}
@@ -100,7 +107,7 @@ export default function Highlights() {
             <p><strong>Expires in:</strong> {Math.ceil(selectedHighlight.expiresIn / 60)} min</p>
             <p>✨ More event details can go here...</p>
 
-            {/* Swipe controls */}
+            {/* Buttons still available for desktop fallback(Swipe Cotrols) */}
             <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 16 }}>
               <Button onClick={goPrev} disabled={currentIndex === 0}>Prev</Button>
               <Button onClick={goNext} disabled={currentIndex === highlights.length - 1}>Next</Button>


### PR DESCRIPTION
feat(highlights): add swipeable navigation in modal

- Integrated react-swipeable for left/right gesture support
- Users can now swipe between highlights on mobile like stories
- Prev/Next buttons remain for desktop as fallback
- Auto-expiry countdown and sticky highlight bar still work as before